### PR TITLE
Fix root URL mapping

### DIFF
--- a/grails-app/conf/UrlMappings.groovy
+++ b/grails-app/conf/UrlMappings.groovy
@@ -8,7 +8,7 @@ class UrlMappings {
         }
 
         // Direkt zu MAB weiterleiten
-        "/"(redirect: "/MAB/index")
+        "/"(controller: 'MAB', action: 'index')
 
         // Error pages
         "500"(view:'/error')


### PR DESCRIPTION
## Summary
- point the root route directly to `MABController.index`

## Testing
- `./gradlew tasks --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6846ded092ac832aa10572fd221eee04