### PR TITLE
Add database-only Docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ Projektziele
 ## Feature asset-pipeline-grails documentation
 
 - [Grails Asset Pipeline Core documentation](https://www.asset-pipeline.com/manual/)
+
+## Docker Compose
+
+To start only the database services for testing, run:
+
+```bash
+docker compose -f docker-compose-db.yml up -d
+```
+
+This launches MySQL and Adminer. Use the standard `docker-compose.yml` to start the full application.

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -1,0 +1,43 @@
+version: '3.8'
+
+services:
+  mab-db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: mab_db
+      MYSQL_USER: mab_user
+      MYSQL_PASSWORD: mab_password
+    ports:
+      - "3306:3306"
+    volumes:
+      - mab_db_data:/var/lib/mysql
+      - ./sql/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 10s
+      retries: 5
+      interval: 30s
+      start_period: 60s
+    networks:
+      - mab-network
+    restart: unless-stopped
+
+  adminer:
+    image: adminer:latest
+    ports:
+      - "8081:8080"
+    environment:
+      ADMINER_DEFAULT_SERVER: mab-db
+    depends_on:
+      - mab-db
+    networks:
+      - mab-network
+    restart: unless-stopped
+
+volumes:
+  mab_db_data:
+
+networks:
+  mab-network:
+    driver: bridge


### PR DESCRIPTION
## Summary
- add `docker-compose-db.yml` for running the MySQL database separately
- document new compose file in README

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68493b09b1f4832aa4d43077c5708165